### PR TITLE
Add release automation with release-plz

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,57 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  release-pr:
+    name: Release PR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: release-pr-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run release-plz (release-pr)
+        uses: MarcoIeni/release-plz-action@63ab0c2746bedc448370bad4b0b3d536458398b0
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release:
+    name: Publish
+    needs: release-pr
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    concurrency:
+      group: release-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Authenticate to crates.io (OIDC)
+        id: crates-io-auth
+        uses: rust-lang/crates-io-auth-action@v1
+
+      - name: Run release-plz (release)
+        uses: MarcoIeni/release-plz-action@63ab0c2746bedc448370bad4b0b3d536458398b0
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,51 @@
+# Releasing rapace
+
+This repository uses [release-plz](https://release-plz.dev) to automate version
+bumping, changelog generation, and publishing to crates.io. The workflow lives
+in `.github/workflows/release-plz.yml` and runs on every push to `main` as well
+as on manual `workflow_dispatch` invocations.
+
+## Crates that ship to crates.io
+
+Only a subset of workspace members are published:
+
+- `rapace`
+- `rapace-core`
+- `rapace-macros`
+- `rapace-registry`
+- `rapace-tracing`
+- `rapace-transport-mem`
+- `rapace-transport-stream`
+- `rapace-transport-websocket`
+- `rapace-transport-shm`
+
+Everything else (`rapace-http`, `rapace-testkit`, `rapace-explorer`,
+`rapace-wasm-client`, demos, xtask helpers, etc.) is marked `publish = false`
+so release-plz will ignore it.
+
+## Tokens and secrets
+
+Trusted Publishing is enabled through `rust-lang/crates-io-auth-action@v1`,
+which exchanges a short-lived crates.io token using GitHub’s OIDC identity. To
+finish setup:
+
+1. On crates.io, for each published crate, go to **Settings → Owners → Trusted
+   publishing**, add this repository, and grant publish+manage permissions.
+2. No long-lived `CARGO_REGISTRY_TOKEN` secret is required; the workflow step
+   writes the ephemeral token to the `CARGO_REGISTRY_TOKEN` env var right before
+   calling `release-plz release`.
+3. The default `GITHUB_TOKEN` continues to power release-plz PR updates.
+
+## Typical workflow
+
+1. Land feature work on `main`.
+2. Wait for the `Release / Release PR` job to run. If a release is warranted,
+   release-plz will either create or update a `release` pull request that bumps
+   versions and changelog entries.
+3. Review and merge the release PR.
+4. The `Release / Publish` job runs automatically on the merge commit and
+   publishes tagged crates using release-plz.
+5. Monitor the workflow logs to ensure the release succeeded.
+
+You can also trigger the workflow manually: `gh workflow run release-plz.yml`.
+This is useful when you need to force a release after cherry-picking fixes.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+# Configure Codecov reporting.
+# The demos/ tree hosts example apps and browser harnesses that should not
+# impact the main workspace's coverage metrics.
+ignore:
+  - "demos/**/*"

--- a/crates/rapace-explorer/Cargo.toml
+++ b/crates/rapace-explorer/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Explorer service for rapace - dynamic service discovery and method invocation"
+publish = false
 
 [dependencies]
 rapace = { path = "../rapace" }

--- a/crates/rapace-http/Cargo.toml
+++ b/crates/rapace-http/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "HTTP types and service trait for rapace RPC"
+publish = false
 
 [dependencies]
 tracing = { workspace = true }

--- a/crates/rapace-testkit/Cargo.toml
+++ b/crates/rapace-testkit/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Conformance test suite for rapace transports"
+publish = false
 
 [dependencies]
 # rapace is required for the #[rapace::service] macro to work

--- a/crates/rapace-wasm-client/Cargo.toml
+++ b/crates/rapace-wasm-client/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "WebAssembly client for rapace RPC (browser support)"
+publish = false
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,45 @@
+[workspace]
+# Only manage releases for explicitly opted-in crates.
+release = false
+# Publish when a release PR is merged instead of on every commit.
+release_always = false
+# Attach a consistent label to release-plz PRs for easier filtering.
+pr_labels = ["release"]
+# Used by release-plz to populate links in the generated changelog.
+repo_url = "https://github.com/bearcove/rapace"
+
+[[package]]
+name = "rapace"
+release = true
+
+[[package]]
+name = "rapace-core"
+release = true
+
+[[package]]
+name = "rapace-macros"
+release = true
+
+[[package]]
+name = "rapace-registry"
+release = true
+
+[[package]]
+name = "rapace-tracing"
+release = true
+
+[[package]]
+name = "rapace-transport-mem"
+release = true
+
+[[package]]
+name = "rapace-transport-stream"
+release = true
+
+[[package]]
+name = "rapace-transport-websocket"
+release = true
+
+[[package]]
+name = "rapace-transport-shm"
+release = true

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -2,6 +2,7 @@
 name = "xtask"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }


### PR DESCRIPTION
Set up release-plz config and workflow to manage releases on main. Document the process in RELEASING.md and enable trusted publishing via crates-io-auth. Limit publishing to the public crates and ignore demos in Codecov.