### PR TITLE
fix: remove incorrect dependency in release-plz workflow

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -30,7 +30,6 @@ jobs:
 
   release:
     name: Publish
-    needs: release-pr
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Fixes the issue raised in #16 Copilot review.

## Problem

The `release` job had `needs: release-pr`, causing both jobs to run sequentially on every push to main. This would attempt to publish packages on every commit to main, which is incorrect behavior.

As Copilot correctly identified:
> The workflow structure has the 'release' job depend on 'release-pr' and run on every push to main, which will attempt to publish on every commit.

## Solution

Removed the `needs: release-pr` dependency. Now both jobs run independently on every push to main:

- **`release-pr`** creates/updates the release PR with version bumps and changelog
- **`release`** publishes to crates.io only when there's actually something to release (i.e., when release-plz detects that a release PR was just merged)

This is the recommended pattern from the [release-plz documentation](https://release-plz.ieni.dev/docs/github/quickstart), where the `release` command is idempotent and will only publish when appropriate.

## How it works

The `release` command is smart enough to:
- ✅ Skip publishing when there's nothing to release
- ✅ Only publish when it detects a release PR was just merged (by checking for version tag changes)
- ✅ Handle the OIDC authentication token properly

## Testing

The workflow logic has been verified to match release-plz best practices. After this change:
- Regular commits to main → only `release-pr` job creates/updates the release PR
- Release PR merged to main → `release` job publishes to crates.io

---

Thanks to GitHub Copilot for catching this issue! 🤖