### PR TITLE
Use newer Ubuntu runner for release workflows

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   release-pr:
     name: Release PR
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-16
     permissions:
       contents: write
       pull-requests: write
@@ -30,7 +30,7 @@ jobs:
 
   release:
     name: Publish
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-16
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
The release workflows were using `ubuntu-latest`, which has an older cached Rust version (1.77.1) that doesn't support the `edition2024` Cargo feature. This caused failures when dependencies like `ur-taking-me-with-you v0.2.0` required this feature.

Updated to use `depot-ubuntu-24.04-16` to match the CI workflows and support newer Rust toolchains.