### PR TITLE
Make RpcError implement Facet for serialization

### DIFF
--- a/crates/rapace-cell/src/lib.rs
+++ b/crates/rapace-cell/src/lib.rs
@@ -563,7 +563,7 @@ where
         Ok(result) => result?,
         Err(join_err) => {
             return Err(CellError::Transport(TransportError::Io(
-                std::io::Error::other(format!("demux task join error: {join_err}")),
+                std::io::Error::other(format!("demux task join error: {join_err}")).into(),
             )));
         }
     }
@@ -674,7 +674,7 @@ where
         Ok(result) => result?,
         Err(join_err) => {
             return Err(CellError::Transport(TransportError::Io(
-                std::io::Error::other(format!("demux task join error: {join_err}")),
+                std::io::Error::other(format!("demux task join error: {join_err}")).into(),
             )));
         }
     }
@@ -868,7 +868,7 @@ where
         Ok(result) => result?,
         Err(join_err) => {
             return Err(CellError::Transport(TransportError::Io(
-                std::io::Error::other(format!("demux task join error: {join_err}")),
+                std::io::Error::other(format!("demux task join error: {join_err}")).into(),
             )));
         }
     }

--- a/crates/rapace-core/src/transport/websocket.rs
+++ b/crates/rapace-core/src/transport/websocket.rs
@@ -239,10 +239,13 @@ mod native {
             let data = recv.recv().await.ok_or(TransportError::Closed)?;
 
             if data.len() < DESC_SIZE {
-                return Err(TransportError::Io(std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    format!("frame too small: {} < {}", data.len(), DESC_SIZE),
-                )));
+                return Err(TransportError::Io(
+                    std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        format!("frame too small: {} < {}", data.len(), DESC_SIZE),
+                    )
+                    .into(),
+                ));
             }
 
             let desc_bytes: [u8; DESC_SIZE] = data[..DESC_SIZE].try_into().unwrap();
@@ -370,10 +373,13 @@ mod wasm {
 
             let data = self.inner.ws.recv().await?;
             if data.len() < DESC_SIZE {
-                return Err(TransportError::Io(std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    format!("frame too small: {} < {}", data.len(), DESC_SIZE),
-                )));
+                return Err(TransportError::Io(
+                    std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        format!("frame too small: {} < {}", data.len(), DESC_SIZE),
+                    )
+                    .into(),
+                ));
             }
 
             let desc_bytes: [u8; DESC_SIZE] = data[..DESC_SIZE].try_into().unwrap();
@@ -574,11 +580,11 @@ mod wasm {
         } else {
             format!("{err:?}")
         };
-        TransportError::Io(std::io::Error::other(msg))
+        TransportError::Io(std::io::Error::other(msg).into())
     }
 
     fn js_error_from_msg<S: Into<String>>(msg: S) -> TransportError {
-        TransportError::Io(std::io::Error::other(msg.into()))
+        TransportError::Io(std::io::Error::other(msg.into()).into())
     }
 }
 


### PR DESCRIPTION
## Summary

Make `RpcError` and related error types serializable with Facet by replacing `std::io::Error` with a custom `IoError` type. This enables safe error propagation across process boundaries.

## Changes

- Create `IoError` and `IoErrorKind` types to wrap `std::io::Error` in a serializable format
- Add `Facet` derives to `ErrorCode`, `ValidationError`, `EncodeError`, `DecodeError`, `TransportError`, and `RpcError`
- Convert RPC serialize/deserialize error fields to store messages as strings
- Add tests verifying Facet implementation

Fixes #59