### PR TITLE
Add documentation and assertions for buffer pool contract

### DIFF
--- a/crates/rapace-cell/src/tracing_setup.rs
+++ b/crates/rapace-cell/src/tracing_setup.rs
@@ -63,7 +63,12 @@ impl ServiceDispatch for TracingConfigService {
     > {
         let server = self.0.clone();
         // Create a new frame with the payload copied - this is necessary because
-        // the SHM guard cannot be cloned
+        // the SHM guard cannot be cloned, and the async task needs to own the data
+        // since it outlives the request scope.
+        //
+        // Performance note: Tracing payloads are typically small (log messages, span
+        // metadata), so this copy is acceptable. For large payloads, consider using
+        // a different tracing strategy.
         let desc = frame.desc;
         let payload = rapace::rapace_core::Payload::Owned(frame.payload_bytes().to_vec());
         let frame_owned = rapace::Frame { desc, payload };

--- a/crates/rapace-core/src/buffer_pool.rs
+++ b/crates/rapace-core/src/buffer_pool.rs
@@ -99,6 +99,7 @@ impl PooledBuf {
     /// The data will be copied into a pooled buffer from the given pool.
     pub fn from_slice(pool: &BufferPool, data: &[u8]) -> Self {
         let mut buf = pool.get();
+        debug_assert_eq!(buf.len(), 0, "pool.get() should return empty buffer");
         buf.extend_from_slice(data);
         buf
     }
@@ -147,7 +148,7 @@ mod tests {
     fn test_buffer_pool_basic() {
         let pool = BufferPool::new();
         let mut buf = pool.get();
-        assert_eq!(buf.len(), 0);
+        assert_eq!(buf.len(), 0, "pool.get() must return empty buffer");
         assert!(buf.capacity() >= DEFAULT_BUFFER_SIZE);
 
         buf.extend_from_slice(b"hello world");
@@ -188,6 +189,7 @@ mod tests {
         assert_eq!(pool.buffer_size(), 1024);
 
         let buf = pool.get();
+        assert_eq!(buf.len(), 0, "pool.get() must return empty buffer");
         assert!(buf.capacity() >= 1024);
     }
 


### PR DESCRIPTION
## Summary

This PR addresses code review feedback on PR #65 by improving documentation and adding defensive assertions to make the buffer pool contract more explicit.

## Changes

1. **Tracing Service Documentation**: Added performance note explaining why the payload copy in `tracing_setup.rs` is acceptable (tracing payloads are typically small: log messages, span metadata).

2. **Buffer Pool Contract Enforcement**: 
   - Added `debug_assert_eq!` in `PooledBuf::from_slice()` to verify `get()` returns empty buffers
   - Added explicit assertions in buffer pool tests to validate the contract
   - Makes the clearing contract explicit and catches regressions

## Rationale

The buffer pool uses a "clear-on-get" strategy where `BufferPool::get()` guarantees returned buffers are empty. This prevents the removed `.clear()` calls in `from_slice()` and tests from becoming a silent dependency on implementation details. The debug assertions make this contract explicit and will catch any regressions.

`★ Insight ─────────────────────────────────────`
**Defense-in-depth with debug assertions**: The `debug_assert_eq!` pattern used here is a powerful technique for documenting invariants. Unlike regular assertions (which add runtime overhead), debug assertions are compiled out in release builds but catch contract violations during development and testing. This is especially valuable for pooling patterns where the contract ("get returns empty buffers") is critical for correctness but not obvious from the type system.
`─────────────────────────────────────────────────`