### PR TITLE
Optimize serialization with buffer pools (#54)

### DIFF
--- a/crates/rapace-core/src/buffer_pool.rs
+++ b/crates/rapace-core/src/buffer_pool.rs
@@ -28,6 +28,14 @@ pub struct BufferPool {
     buffer_size: usize,
 }
 
+impl std::fmt::Debug for BufferPool {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BufferPool")
+            .field("buffer_size", &self.buffer_size)
+            .finish_non_exhaustive()
+    }
+}
+
 impl BufferPool {
     /// Create a new buffer pool with default settings.
     ///

--- a/crates/rapace-core/src/error.rs
+++ b/crates/rapace-core/src/error.rs
@@ -344,6 +344,12 @@ impl fmt::Display for EncodeError {
 
 impl std::error::Error for EncodeError {}
 
+impl From<facet_postcard::SerializeError> for EncodeError {
+    fn from(e: facet_postcard::SerializeError) -> Self {
+        Self::EncodeFailed(e.to_string())
+    }
+}
+
 /// Decoding errors.
 #[derive(Debug, Clone, facet::Facet)]
 #[repr(u8)]
@@ -418,6 +424,18 @@ impl From<facet_postcard::SerializeError> for RpcError {
 
 impl From<facet_postcard::DeserializeError> for RpcError {
     fn from(e: facet_postcard::DeserializeError) -> Self {
+        Self::Deserialize(e.to_string())
+    }
+}
+
+impl From<EncodeError> for RpcError {
+    fn from(e: EncodeError) -> Self {
+        Self::Serialize(e.to_string())
+    }
+}
+
+impl From<DecodeError> for RpcError {
+    fn from(e: DecodeError) -> Self {
         Self::Deserialize(e.to_string())
     }
 }

--- a/crates/rapace-core/src/transport.rs
+++ b/crates/rapace-core/src/transport.rs
@@ -7,7 +7,7 @@
 
 use enum_dispatch::enum_dispatch;
 
-use crate::{Frame, TransportError};
+use crate::{BufferPool, Frame, TransportError};
 
 #[enum_dispatch]
 pub(crate) trait TransportBackend: Send + Sync + Clone + 'static {
@@ -15,6 +15,7 @@ pub(crate) trait TransportBackend: Send + Sync + Clone + 'static {
     async fn recv_frame(&self) -> Result<Frame, TransportError>;
     fn close(&self);
     fn is_closed(&self) -> bool;
+    fn buffer_pool(&self) -> &BufferPool;
 }
 
 #[enum_dispatch(TransportBackend)]
@@ -45,6 +46,14 @@ impl Transport {
 
     pub fn is_closed(&self) -> bool {
         TransportBackend::is_closed(self)
+    }
+
+    /// Get the buffer pool for this transport.
+    ///
+    /// This pool is used for optimized serialization and deserialization,
+    /// avoiding allocations by reusing buffers across multiple RPCs.
+    pub fn buffer_pool(&self) -> &BufferPool {
+        TransportBackend::buffer_pool(self)
     }
 
     #[cfg(feature = "mem")]

--- a/crates/rapace-core/src/transport/mem.rs
+++ b/crates/rapace-core/src/transport/mem.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use tokio::sync::mpsc;
 
-use crate::{Frame, Payload, TransportError};
+use crate::{BufferPool, Frame, Payload, TransportError};
 
 use super::TransportBackend;
 
@@ -11,6 +11,7 @@ const CHANNEL_CAPACITY: usize = 64;
 #[derive(Clone, Debug)]
 pub struct MemTransport {
     inner: Arc<MemInner>,
+    buffer_pool: BufferPool,
 }
 
 #[derive(Debug)]
@@ -37,7 +38,16 @@ impl MemTransport {
             closed: std::sync::atomic::AtomicBool::new(false),
         });
 
-        (Self { inner: inner_a }, Self { inner: inner_b })
+        (
+            Self {
+                inner: inner_a,
+                buffer_pool: BufferPool::new(),
+            },
+            Self {
+                inner: inner_b,
+                buffer_pool: BufferPool::new(),
+            },
+        )
     }
 
     fn is_closed_inner(&self) -> bool {
@@ -83,5 +93,9 @@ impl TransportBackend for MemTransport {
 
     fn is_closed(&self) -> bool {
         self.is_closed_inner()
+    }
+
+    fn buffer_pool(&self) -> &BufferPool {
+        &self.buffer_pool
     }
 }

--- a/crates/rapace-core/src/transport/shm/hub_transport.rs
+++ b/crates/rapace-core/src/transport/shm/hub_transport.rs
@@ -329,6 +329,10 @@ impl TransportBackend for HubPeerTransport {
     fn is_closed(&self) -> bool {
         self.inner.closed.load(Ordering::Acquire)
     }
+
+    fn buffer_pool(&self) -> &BufferPool {
+        &self.inner.buffer_pool
+    }
 }
 
 // =============================================================================
@@ -597,5 +601,9 @@ impl TransportBackend for HubHostPeerTransport {
 
     fn is_closed(&self) -> bool {
         self.inner.closed.load(Ordering::Acquire)
+    }
+
+    fn buffer_pool(&self) -> &BufferPool {
+        &self.inner.buffer_pool
     }
 }

--- a/crates/rapace-core/src/transport/stream.rs
+++ b/crates/rapace-core/src/transport/stream.rs
@@ -184,4 +184,8 @@ impl TransportBackend for StreamTransport {
     fn is_closed(&self) -> bool {
         self.is_closed_inner()
     }
+
+    fn buffer_pool(&self) -> &crate::BufferPool {
+        &self.inner.buffer_pool
+    }
 }

--- a/crates/rapace-core/src/transport/websocket.rs
+++ b/crates/rapace-core/src/transport/websocket.rs
@@ -308,6 +308,10 @@ mod native {
         fn is_closed(&self) -> bool {
             self.is_closed_inner()
         }
+
+        fn buffer_pool(&self) -> &crate::BufferPool {
+            &self.inner.buffer_pool
+        }
     }
 }
 
@@ -456,6 +460,10 @@ mod wasm {
 
         fn is_closed(&self) -> bool {
             self.is_closed_inner()
+        }
+
+        fn buffer_pool(&self) -> &crate::BufferPool {
+            &self.inner.buffer_pool
         }
     }
 


### PR DESCRIPTION
## Summary

Implements pooled serialization to reduce allocations in RPC hot paths by eliminating unconditional `to_vec()` calls. Avoids repeated memory allocations for frequently-used request/response payloads through reusable buffer pools.

## Changes

- Add `buffer_pool()` method to all transport backends (mem, stream, SHM, WebSocket)
- Add `postcard_to_pooled_buf()` helper using `to_slice()` for direct serialization
- Add `call_pooled()` and `start_streaming_call_pooled()` to RpcSession
- Update macro-generated client code to use pooled serialization
- Update macro-generated streaming server dispatch to use pooled serialization

## Optimization Coverage

- ✅ Client-side request serialization (`call_pooled`)
- ✅ Server-side streaming response serialization (`dispatch_streaming`)
- ⚠️ Server-side unary response serialization (`dispatch`) - requires API-breaking change (see #76)

## Related

Closes #54. See #76 for completing server-side unary optimization.