### PR TITLE
Pass buffer pool to server-side unary dispatch

### DIFF
--- a/crates/rapace-cell/src/tracing_setup.rs
+++ b/crates/rapace-cell/src/tracing_setup.rs
@@ -5,7 +5,7 @@
 
 use std::sync::Arc;
 
-use rapace::RpcSession;
+use rapace::{BufferPool, RpcSession};
 use rapace_tracing::{RapaceTracingLayer, SharedFilter, TracingConfigImpl, TracingConfigServer};
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
@@ -54,6 +54,7 @@ impl ServiceDispatch for TracingConfigService {
         &self,
         method_id: u32,
         frame: &rapace::Frame,
+        buffer_pool: &BufferPool,
     ) -> std::pin::Pin<
         Box<
             dyn std::future::Future<Output = Result<rapace::Frame, rapace::RpcError>>
@@ -72,6 +73,7 @@ impl ServiceDispatch for TracingConfigService {
         let desc = frame.desc;
         let payload = rapace::rapace_core::Payload::Owned(frame.payload_bytes().to_vec());
         let frame_owned = rapace::Frame { desc, payload };
-        Box::pin(async move { server.dispatch(method_id, &frame_owned).await })
+        let buffer_pool = buffer_pool.clone();
+        Box::pin(async move { server.dispatch(method_id, &frame_owned, &buffer_pool).await })
     }
 }

--- a/demos/http-over-rapace/src/helper.rs
+++ b/demos/http-over-rapace/src/helper.rs
@@ -145,7 +145,10 @@ async fn run_cell(transport: Transport) {
     let http_service = AxumHttpService::with_demo_routes();
 
     // Set up HttpService dispatcher
-    session.set_dispatcher(create_http_service_dispatcher(http_service));
+    session.set_dispatcher(create_http_service_dispatcher(
+        http_service,
+        session.buffer_pool().clone(),
+    ));
 
     // Run the session until the transport closes
     eprintln!("[http-cell] Session running...");

--- a/demos/http-over-rapace/src/main.rs
+++ b/demos/http-over-rapace/src/main.rs
@@ -39,7 +39,10 @@ async fn main() {
     let http_service = AxumHttpService::with_demo_routes();
 
     // Set dispatcher for HttpService
-    cell_session.set_dispatcher(create_http_service_dispatcher(http_service));
+    cell_session.set_dispatcher(create_http_service_dispatcher(
+        http_service,
+        cell_session.buffer_pool().clone(),
+    ));
 
     // Spawn the cell's demux loop
     let cell_session_clone = cell_session.clone();
@@ -207,7 +210,10 @@ mod tests {
         // Plugin session (even channel IDs)
         let plugin_session = Arc::new(RpcSession::with_channel_start(plugin_transport.clone(), 2));
         let http_service = AxumHttpService::with_demo_routes();
-        plugin_session.set_dispatcher(create_http_service_dispatcher(http_service));
+        plugin_session.set_dispatcher(create_http_service_dispatcher(
+            http_service,
+            plugin_session.buffer_pool().clone(),
+        ));
         let plugin_session_clone = plugin_session.clone();
         let plugin_handle = tokio::spawn(async move { plugin_session_clone.run().await });
 
@@ -358,7 +364,10 @@ mod tests {
 
         let plugin_session = Arc::new(RpcSession::with_channel_start(plugin_transport.clone(), 2));
         let http_service = AxumHttpService::with_demo_routes();
-        plugin_session.set_dispatcher(create_http_service_dispatcher(http_service));
+        plugin_session.set_dispatcher(create_http_service_dispatcher(
+            http_service,
+            plugin_session.buffer_pool().clone(),
+        ));
         let plugin_session_clone = plugin_session.clone();
         let plugin_handle = tokio::spawn(async move { plugin_session_clone.run().await });
 
@@ -384,7 +393,10 @@ mod tests {
 
         let plugin_session = Arc::new(RpcSession::with_channel_start(plugin_transport.clone(), 2));
         let http_service = AxumHttpService::with_demo_routes();
-        plugin_session.set_dispatcher(create_http_service_dispatcher(http_service));
+        plugin_session.set_dispatcher(create_http_service_dispatcher(
+            http_service,
+            plugin_session.buffer_pool().clone(),
+        ));
         let plugin_session_clone = plugin_session.clone();
         let plugin_handle = tokio::spawn(async move { plugin_session_clone.run().await });
 
@@ -419,7 +431,10 @@ mod tests {
 
         let plugin_session = Arc::new(RpcSession::with_channel_start(plugin_transport.clone(), 2));
         let http_service = AxumHttpService::with_demo_routes();
-        plugin_session.set_dispatcher(create_http_service_dispatcher(http_service));
+        plugin_session.set_dispatcher(create_http_service_dispatcher(
+            http_service,
+            plugin_session.buffer_pool().clone(),
+        ));
         let plugin_session_clone = plugin_session.clone();
         let plugin_handle = tokio::spawn(async move { plugin_session_clone.run().await });
 
@@ -458,7 +473,10 @@ mod tests {
 
         let plugin_session = Arc::new(RpcSession::with_channel_start(plugin_transport.clone(), 2));
         let http_service = AxumHttpService::with_demo_routes();
-        plugin_session.set_dispatcher(create_http_service_dispatcher(http_service));
+        plugin_session.set_dispatcher(create_http_service_dispatcher(
+            http_service,
+            plugin_session.buffer_pool().clone(),
+        ));
         let plugin_session_clone = plugin_session.clone();
         let plugin_handle = tokio::spawn(async move { plugin_session_clone.run().await });
 

--- a/demos/http-tunnel/src/main.rs
+++ b/demos/http-tunnel/src/main.rs
@@ -55,7 +55,10 @@ async fn main() {
     ));
 
     // Set dispatcher for TcpTunnel service
-    cell_session.set_dispatcher(create_tunnel_dispatcher(tunnel_service.clone()));
+    cell_session.set_dispatcher(create_tunnel_dispatcher(
+        tunnel_service.clone(),
+        cell_session.buffer_pool().clone(),
+    ));
 
     // Spawn the cell's demux loop
     let cell_session_clone = cell_session.clone();

--- a/demos/http-tunnel/src/plugin_bin.rs
+++ b/demos/http-tunnel/src/plugin_bin.rs
@@ -91,7 +91,10 @@ async fn run_plugin(transport: Transport) {
     ));
 
     // Set dispatcher
-    session.set_dispatcher(create_tunnel_dispatcher(tunnel_service));
+    session.set_dispatcher(create_tunnel_dispatcher(
+        tunnel_service,
+        session.buffer_pool().clone(),
+    ));
 
     // Run the session until the transport closes
     eprintln!("[http-tunnel-plugin] Session running...");

--- a/demos/http-tunnel/tests/integration.rs
+++ b/demos/http-tunnel/tests/integration.rs
@@ -23,7 +23,10 @@ async fn start_plugin(session: Arc<RpcSession>, http_port: u16) -> Arc<GlobalTun
     ));
 
     // Set dispatcher
-    session.set_dispatcher(create_tunnel_dispatcher(tunnel_service));
+    session.set_dispatcher(create_tunnel_dispatcher(
+        tunnel_service,
+        session.buffer_pool().clone(),
+    ));
 
     // Spawn demux loop
     let session_clone = session.clone();

--- a/demos/template-engine/src/helper.rs
+++ b/demos/template-engine/src/helper.rs
@@ -143,7 +143,10 @@ async fn run_plugin(transport: Transport) {
     let session = Arc::new(RpcSession::with_channel_start(transport, 2));
 
     // Set up TemplateEngine dispatcher
-    session.set_dispatcher(create_template_engine_dispatcher(session.clone()));
+    session.set_dispatcher(create_template_engine_dispatcher(
+        session.clone(),
+        session.buffer_pool().clone(),
+    ));
 
     // Run the session until the transport closes
     eprintln!("[helper] Plugin session running...");

--- a/demos/template-engine/src/main.rs
+++ b/demos/template-engine/src/main.rs
@@ -56,7 +56,10 @@ async fn main() {
     let host_session = Arc::new(RpcSession::with_channel_start(host_transport, 1));
 
     // Set dispatcher for ValueHost service
-    host_session.set_dispatcher(create_value_host_dispatcher(value_host_impl.clone()));
+    host_session.set_dispatcher(create_value_host_dispatcher(
+        value_host_impl.clone(),
+        host_session.buffer_pool().clone(),
+    ));
 
     // Spawn the host's demux loop
     let host_session_clone = host_session.clone();
@@ -67,7 +70,10 @@ async fn main() {
     let cell_session = Arc::new(RpcSession::with_channel_start(cell_transport, 2));
 
     // Set dispatcher for TemplateEngine service
-    cell_session.set_dispatcher(create_template_engine_dispatcher(cell_session.clone()));
+    cell_session.set_dispatcher(create_template_engine_dispatcher(
+        cell_session.clone(),
+        cell_session.buffer_pool().clone(),
+    ));
 
     // Spawn the cell's demux loop
     let cell_session_clone = cell_session.clone();
@@ -133,13 +139,19 @@ mod tests {
 
         // Host session (odd channel IDs)
         let host_session = Arc::new(RpcSession::with_channel_start(host_transport, 1));
-        host_session.set_dispatcher(create_value_host_dispatcher(value_host_impl.clone()));
+        host_session.set_dispatcher(create_value_host_dispatcher(
+            value_host_impl.clone(),
+            host_session.buffer_pool().clone(),
+        ));
         let host_session_clone = host_session.clone();
         let host_handle = tokio::spawn(async move { host_session_clone.run().await });
 
         // Cell session (even channel IDs)
         let cell_session = Arc::new(RpcSession::with_channel_start(cell_transport, 2));
-        cell_session.set_dispatcher(create_template_engine_dispatcher(cell_session.clone()));
+        cell_session.set_dispatcher(create_template_engine_dispatcher(
+            cell_session.clone(),
+            cell_session.buffer_pool().clone(),
+        ));
         let cell_session_clone = cell_session.clone();
         let cell_handle = tokio::spawn(async move { cell_session_clone.run().await });
 
@@ -173,12 +185,18 @@ mod tests {
         let value_host_impl = Arc::new(value_host_impl);
 
         let host_session = Arc::new(RpcSession::with_channel_start(host_transport, 1));
-        host_session.set_dispatcher(create_value_host_dispatcher(value_host_impl.clone()));
+        host_session.set_dispatcher(create_value_host_dispatcher(
+            value_host_impl.clone(),
+            host_session.buffer_pool().clone(),
+        ));
         let host_session_clone = host_session.clone();
         let host_handle = tokio::spawn(async move { host_session_clone.run().await });
 
         let cell_session = Arc::new(RpcSession::with_channel_start(cell_transport, 2));
-        cell_session.set_dispatcher(create_template_engine_dispatcher(cell_session.clone()));
+        cell_session.set_dispatcher(create_template_engine_dispatcher(
+            cell_session.clone(),
+            cell_session.buffer_pool().clone(),
+        ));
         let cell_session_clone = cell_session.clone();
         let cell_handle = tokio::spawn(async move { cell_session_clone.run().await });
 
@@ -206,12 +224,18 @@ mod tests {
         let value_host_impl = Arc::new(value_host_impl);
 
         let host_session = Arc::new(RpcSession::with_channel_start(host_transport, 1));
-        host_session.set_dispatcher(create_value_host_dispatcher(value_host_impl.clone()));
+        host_session.set_dispatcher(create_value_host_dispatcher(
+            value_host_impl.clone(),
+            host_session.buffer_pool().clone(),
+        ));
         let host_session_clone = host_session.clone();
         let host_handle = tokio::spawn(async move { host_session_clone.run().await });
 
         let cell_session = Arc::new(RpcSession::with_channel_start(cell_transport, 2));
-        cell_session.set_dispatcher(create_template_engine_dispatcher(cell_session.clone()));
+        cell_session.set_dispatcher(create_template_engine_dispatcher(
+            cell_session.clone(),
+            cell_session.buffer_pool().clone(),
+        ));
         let cell_session_clone = cell_session.clone();
         let cell_handle = tokio::spawn(async move { cell_session_clone.run().await });
 
@@ -235,12 +259,18 @@ mod tests {
         let value_host_impl = Arc::new(ValueHostImpl::new()); // Empty
 
         let host_session = Arc::new(RpcSession::with_channel_start(host_transport, 1));
-        host_session.set_dispatcher(create_value_host_dispatcher(value_host_impl.clone()));
+        host_session.set_dispatcher(create_value_host_dispatcher(
+            value_host_impl.clone(),
+            host_session.buffer_pool().clone(),
+        ));
         let host_session_clone = host_session.clone();
         let host_handle = tokio::spawn(async move { host_session_clone.run().await });
 
         let cell_session = Arc::new(RpcSession::with_channel_start(cell_transport, 2));
-        cell_session.set_dispatcher(create_template_engine_dispatcher(cell_session.clone()));
+        cell_session.set_dispatcher(create_template_engine_dispatcher(
+            cell_session.clone(),
+            cell_session.buffer_pool().clone(),
+        ));
         let cell_session_clone = cell_session.clone();
         let cell_handle = tokio::spawn(async move { cell_session_clone.run().await });
 

--- a/demos/template-engine/tests/cross_process.rs
+++ b/demos/template-engine/tests/cross_process.rs
@@ -169,7 +169,10 @@ async fn run_host_scenario(transport: Transport) -> String {
 
     // Host uses odd channel IDs (1, 3, 5, ...)
     let session = Arc::new(RpcSession::with_channel_start(transport, 1));
-    session.set_dispatcher(create_value_host_dispatcher(value_host_impl.clone()));
+    session.set_dispatcher(create_value_host_dispatcher(
+        value_host_impl.clone(),
+        session.buffer_pool().clone(),
+    ));
 
     // Spawn the session runner
     let session_clone = session.clone();

--- a/demos/template-engine/tests/peer_death.rs
+++ b/demos/template-engine/tests/peer_death.rs
@@ -148,7 +148,10 @@ async fn test_stream_helper_death() {
     let value_host_impl = Arc::new(value_host_impl);
 
     let session = Arc::new(RpcSession::with_channel_start(transport, 1));
-    session.set_dispatcher(create_value_host_dispatcher(value_host_impl.clone()));
+    session.set_dispatcher(create_value_host_dispatcher(
+        value_host_impl.clone(),
+        session.buffer_pool().clone(),
+    ));
 
     let session_clone = session.clone();
     let session_handle = tokio::spawn(async move { session_clone.run().await });
@@ -232,7 +235,10 @@ async fn test_stream_host_death() {
     let value_host_impl = Arc::new(value_host_impl);
 
     let session = Arc::new(RpcSession::with_channel_start(transport, 1));
-    session.set_dispatcher(create_value_host_dispatcher(value_host_impl.clone()));
+    session.set_dispatcher(create_value_host_dispatcher(
+        value_host_impl.clone(),
+        session.buffer_pool().clone(),
+    ));
 
     let session_clone = session.clone();
     let session_handle = tokio::spawn(async move { session_clone.run().await });
@@ -351,7 +357,10 @@ async fn test_shm_helper_death() {
     let value_host_impl = Arc::new(value_host_impl);
 
     let session = Arc::new(RpcSession::with_channel_start(transport, 1));
-    session.set_dispatcher(create_value_host_dispatcher(value_host_impl.clone()));
+    session.set_dispatcher(create_value_host_dispatcher(
+        value_host_impl.clone(),
+        session.buffer_pool().clone(),
+    ));
 
     let session_clone = session.clone();
     let session_handle = tokio::spawn(async move { session_clone.run().await });

--- a/demos/tracing-over-rapace/src/main.rs
+++ b/demos/tracing-over-rapace/src/main.rs
@@ -32,7 +32,10 @@ async fn main() {
     let host_session = Arc::new(RpcSession::with_channel_start(host_transport, 1));
 
     // Set dispatcher for TracingSink service
-    host_session.set_dispatcher(create_tracing_sink_dispatcher(tracing_sink.clone()));
+    host_session.set_dispatcher(create_tracing_sink_dispatcher(
+        tracing_sink.clone(),
+        host_session.buffer_pool().clone(),
+    ));
 
     // Spawn the host's demux loop
     let host_session_clone = host_session.clone();
@@ -153,7 +156,10 @@ mod tests {
         // Host side
         let tracing_sink = HostTracingSink::new();
         let host_session = Arc::new(RpcSession::with_channel_start(host_transport, 1));
-        host_session.set_dispatcher(create_tracing_sink_dispatcher(tracing_sink.clone()));
+        host_session.set_dispatcher(create_tracing_sink_dispatcher(
+            tracing_sink.clone(),
+            host_session.buffer_pool().clone(),
+        ));
         let host_session_clone = host_session.clone();
         let host_handle = tokio::spawn(async move { host_session_clone.run().await });
 
@@ -240,7 +246,10 @@ mod tests {
 
         let tracing_sink = HostTracingSink::new();
         let host_session = Arc::new(RpcSession::with_channel_start(host_transport, 1));
-        host_session.set_dispatcher(create_tracing_sink_dispatcher(tracing_sink.clone()));
+        host_session.set_dispatcher(create_tracing_sink_dispatcher(
+            tracing_sink.clone(),
+            host_session.buffer_pool().clone(),
+        ));
         let host_session_clone = host_session.clone();
         let host_handle = tokio::spawn(async move { host_session_clone.run().await });
 
@@ -300,7 +309,10 @@ mod tests {
 
         let tracing_sink = HostTracingSink::new();
         let host_session = Arc::new(RpcSession::with_channel_start(host_transport, 1));
-        host_session.set_dispatcher(create_tracing_sink_dispatcher(tracing_sink.clone()));
+        host_session.set_dispatcher(create_tracing_sink_dispatcher(
+            tracing_sink.clone(),
+            host_session.buffer_pool().clone(),
+        ));
         let host_session_clone = host_session.clone();
         let host_handle = tokio::spawn(async move { host_session_clone.run().await });
 

--- a/demos/tracing-over-rapace/tests/cross_process.rs
+++ b/demos/tracing-over-rapace/tests/cross_process.rs
@@ -165,7 +165,10 @@ async fn run_host_scenario(transport: Transport) -> Vec<TraceRecord> {
 
     // Host uses odd channel IDs (1, 3, 5, ...)
     let session = std::sync::Arc::new(RpcSession::with_channel_start(transport, 1));
-    session.set_dispatcher(create_tracing_sink_dispatcher(tracing_sink.clone()));
+    session.set_dispatcher(create_tracing_sink_dispatcher(
+        tracing_sink.clone(),
+        session.buffer_pool().clone(),
+    ));
 
     // Spawn the session runner
     let session_clone = session.clone();


### PR DESCRIPTION
Enable pooled serialization for server-side unary response encoding by passing the buffer pool to the dispatch() method. This completes the optimization from #54.

## Changes

- Added `buffer_pool: &BufferPool` parameter to `dispatch()` method
- Updated `generate_dispatch_arm_unary()` to use pooled serialization
- Updated all dispatcher implementations across crates and demos
- This is a breaking API change for custom dispatch implementations

## Testing

All 36 nextest tests pass, including cross-process and peer_death scenarios.