### PR TITLE
Eliminate frame copying in RPC dispatch

### DIFF
--- a/crates/rapace-core/src/frame.rs
+++ b/crates/rapace-core/src/frame.rs
@@ -136,4 +136,16 @@ impl Frame {
     pub fn payload_bytes(&self) -> &[u8] {
         self.payload.as_slice(&self.desc)
     }
+
+    /// Create a new frame with an owned copy of this frame's payload.
+    ///
+    /// This is useful when you need to extend the lifetime of frame data
+    /// (e.g., moving into an async task) but the original payload is backed
+    /// by shared memory or another non-cloneable source.
+    pub fn to_owned(&self) -> Self {
+        Self {
+            desc: self.desc,
+            payload: Payload::Owned(self.payload_bytes().to_vec()),
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Replaces round-robin service iteration with O(1) HashMap lookup by method ID, eliminating unnecessary frame copying in the hot RPC dispatch path.

## Changes

- **ServiceDispatch trait**: Added `method_ids()` to declare handled methods at registration time
- **DispatcherBuilder**: Now uses `HashMap<u32, Arc<dyn ServiceDispatch>>` for direct lookup instead of Vec
- **dispatch()**: Single hashmap lookup, frame moved directly to service (no copies)
- **cell_service! macro**: Now requires method IDs as third argument
- **Frame::to_owned()**: Added helper for cases where copying is unavoidable

## Motivation

Previously, dispatching a 16MB request through 3 services would copy it twice (once for each failed lookup). Now: O(1) lookup, zero copies in the hot path.