### PR TITLE
Fix cell_service! macro and add duplicate detection (#82 + #83)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1899,6 +1899,7 @@ dependencies = [
  "libc",
  "object-pool",
  "parking_lot",
+ "rapace-registry",
  "shm-primitives",
  "static_assertions",
  "tokio",

--- a/crates/rapace-cell/tests/dispatcher_builder.rs
+++ b/crates/rapace-cell/tests/dispatcher_builder.rs
@@ -1,0 +1,226 @@
+//! Test for DispatcherBuilder duplicate method_id detection and cell_service! macro.
+//!
+//! This validates the fix for issue #82, ensuring that:
+//! 1. cell_service! macro uses the generated METHOD_IDS constant
+//! 2. DispatcherBuilder detects duplicate method_id registrations
+//! 3. Multi-service cells work correctly with O(1) HashMap dispatch
+
+use rapace_cell::*;
+use std::sync::Arc;
+
+// Define two simple services for testing
+#[allow(async_fn_in_trait)]
+#[rapace::service]
+trait ServiceA {
+    async fn method_a(&self) -> String;
+}
+
+#[allow(async_fn_in_trait)]
+#[rapace::service]
+trait ServiceB {
+    async fn method_b(&self) -> String;
+}
+
+struct ServiceAImpl;
+struct ServiceBImpl;
+
+impl ServiceA for ServiceAImpl {
+    async fn method_a(&self) -> String {
+        "Hello from Service A".to_string()
+    }
+}
+
+impl ServiceB for ServiceBImpl {
+    async fn method_b(&self) -> String {
+        "Hello from Service B".to_string()
+    }
+}
+
+#[test]
+fn test_cell_service_macro_uses_method_ids() {
+    // This test verifies that cell_service! can be used with just two parameters
+    // and automatically uses the METHOD_IDS constant
+
+    mod test_cell {
+        use super::*;
+        rapace_cell::cell_service!(ServiceAServer<ServiceAImpl>, ServiceAImpl);
+
+        pub fn get_method_ids() -> &'static [u32] {
+            let service = CellService::from(ServiceAImpl);
+            service.method_ids()
+        }
+    }
+
+    let method_ids = test_cell::get_method_ids();
+
+    // Should match the generated METHOD_IDS constant
+    assert_eq!(method_ids, ServiceAServer::<ServiceAImpl>::METHOD_IDS);
+    assert_eq!(method_ids.len(), 1); // ServiceA has one method
+}
+
+#[test]
+#[should_panic(expected = "duplicate registration for method")]
+fn test_duplicate_method_id_detection() {
+    // This test verifies that DispatcherBuilder panics when the same method_id
+    // is registered twice
+
+    mod test_cell {
+        use super::*;
+        rapace_cell::cell_service!(ServiceAServer<ServiceAImpl>, ServiceAImpl);
+
+        pub fn build_dispatcher_twice() {
+            // This should panic because we're adding the same service twice
+            let _ = DispatcherBuilder::new()
+                .add_service(CellService::from(ServiceAImpl))
+                .add_service(CellService::from(ServiceAImpl)); // PANIC: duplicate method_id
+        }
+    }
+
+    test_cell::build_dispatcher_twice();
+}
+
+#[test]
+fn test_multi_service_dispatcher() {
+    // This test verifies that multiple different services can be added
+    // to the same dispatcher without conflicts
+
+    mod service_a_cell {
+        use super::*;
+        rapace_cell::cell_service!(ServiceAServer<ServiceAImpl>, ServiceAImpl);
+
+        pub fn build_dispatcher(builder: DispatcherBuilder) -> DispatcherBuilder {
+            builder.add_service(CellService::from(ServiceAImpl))
+        }
+    }
+
+    mod service_b_cell {
+        use super::*;
+        rapace_cell::cell_service!(ServiceBServer<ServiceBImpl>, ServiceBImpl);
+
+        pub fn build_dispatcher(builder: DispatcherBuilder) -> DispatcherBuilder {
+            builder.add_service(CellService::from(ServiceBImpl))
+        }
+    }
+
+    // Verify that METHOD_IDS are different
+    assert_ne!(
+        ServiceAServer::<ServiceAImpl>::METHOD_IDS[0],
+        ServiceBServer::<ServiceBImpl>::METHOD_IDS[0],
+        "Services should have different method IDs"
+    );
+
+    // Should successfully build a multi-service dispatcher
+    let builder = DispatcherBuilder::new();
+    let builder = service_a_cell::build_dispatcher(builder);
+    let builder = service_b_cell::build_dispatcher(builder);
+
+    // If we got here without panicking, duplicate detection works correctly
+    let buffer_pool = BufferPool::new();
+    let _dispatcher = builder.build(buffer_pool);
+}
+
+#[tokio::test]
+async fn test_multi_service_dispatch_e2e() -> Result<(), Box<dyn std::error::Error>> {
+    // End-to-end test: create a cell with multiple services and verify routing works
+
+    mod service_a_cell {
+        use super::*;
+        rapace_cell::cell_service!(ServiceAServer<ServiceAImpl>, ServiceAImpl);
+
+        pub fn build_dispatcher(builder: DispatcherBuilder) -> DispatcherBuilder {
+            builder.add_service(CellService::from(ServiceAImpl))
+        }
+    }
+
+    mod service_b_cell {
+        use super::*;
+        rapace_cell::cell_service!(ServiceBServer<ServiceBImpl>, ServiceBImpl);
+
+        pub fn build_dispatcher(builder: DispatcherBuilder) -> DispatcherBuilder {
+            builder.add_service(CellService::from(ServiceBImpl))
+        }
+    }
+
+    // Start a multi-service cell
+    let (client_transport, server_transport) = rapace::Transport::mem_pair();
+
+    // Build the multi-service dispatcher
+    let buffer_pool = BufferPool::new();
+    let builder = DispatcherBuilder::new();
+    let builder = service_a_cell::build_dispatcher(builder);
+    let builder = service_b_cell::build_dispatcher(builder);
+    let dispatcher = builder.build(buffer_pool);
+
+    // Run the dispatcher in the background
+    let dispatcher_handle = tokio::spawn(async move {
+        loop {
+            match server_transport.recv_frame().await {
+                Ok(request) => {
+                    let response = dispatcher(request).await;
+                    match response {
+                        Ok(frame) => {
+                            if let Err(e) = server_transport.send_frame(frame).await {
+                                tracing::error!(?e, "Failed to send response");
+                                break;
+                            }
+                        }
+                        Err(e) => {
+                            tracing::error!(?e, "Dispatch error");
+                            break;
+                        }
+                    }
+                }
+                Err(rapace::TransportError::Closed) => break,
+                Err(e) => {
+                    tracing::error!(?e, "Transport error");
+                    break;
+                }
+            }
+        }
+    });
+
+    // Create client session and spawn demux loop
+    let session = Arc::new(RpcSession::new(client_transport.clone()));
+    let session_clone = session.clone();
+    tokio::spawn(async move {
+        let _ = session_clone.run().await;
+    });
+
+    // Test ServiceA
+    let client_a = ServiceAClient::new(session.clone());
+    let result = client_a.method_a().await?;
+    assert_eq!(result, "Hello from Service A");
+
+    // Test ServiceB
+    let client_b = ServiceBClient::new(session.clone());
+    let result = client_b.method_b().await?;
+    assert_eq!(result, "Hello from Service B");
+
+    // Cleanup
+    client_transport.close();
+    dispatcher_handle.abort();
+
+    Ok(())
+}
+
+#[test]
+fn test_method_ids_match_constants() {
+    // Verify that the cell_service! macro correctly uses the METHOD_IDS constant
+    mod test_cell {
+        use super::*;
+        rapace_cell::cell_service!(ServiceAServer<ServiceAImpl>, ServiceAImpl);
+
+        pub fn get_method_ids() -> &'static [u32] {
+            let service = CellService::from(ServiceAImpl);
+            service.method_ids()
+        }
+    }
+
+    let method_ids = test_cell::get_method_ids();
+
+    // The method_ids() should return exactly what METHOD_IDS contains
+    assert_eq!(method_ids, ServiceAServer::<ServiceAImpl>::METHOD_IDS);
+
+    // And it should contain the individual method ID constant
+    assert!(method_ids.contains(&SERVICE_A_METHOD_ID_METHOD_A));
+}

--- a/crates/rapace-core/Cargo.toml
+++ b/crates/rapace-core/Cargo.toml
@@ -38,6 +38,7 @@ futures-timeout.workspace = true
 libc = { workspace = true, optional = true }
 object-pool.workspace = true
 parking_lot.workspace = true
+rapace-registry.workspace = true
 static_assertions = { workspace = true, optional = true }
 shm-primitives = { workspace = true, optional = true }
 tokio.workspace = true

--- a/crates/rapace-core/src/session.rs
+++ b/crates/rapace-core/src/session.rs
@@ -755,12 +755,28 @@ impl RpcSession {
                 });
             }
             Err(_elapsed) => {
-                tracing::error!(
-                    channel_id,
-                    method_id,
-                    timeout_ms,
-                    "RPC call timed out waiting for response"
-                );
+                // Look up method name from registry for better error messages
+                let method_name = rapace_registry::ServiceRegistry::with_global(|reg| {
+                    reg.method_by_id(rapace_registry::MethodId(method_id))
+                        .map(|m| m.full_name.clone())
+                });
+
+                if let Some(method) = method_name {
+                    tracing::error!(
+                        channel_id,
+                        method = method.as_str(),
+                        method_id,
+                        timeout_ms,
+                        "RPC call timed out waiting for response"
+                    );
+                } else {
+                    tracing::error!(
+                        channel_id,
+                        method_id,
+                        timeout_ms,
+                        "RPC call timed out waiting for response"
+                    );
+                }
                 return Err(RpcError::DeadlineExceeded);
             }
         };
@@ -866,12 +882,28 @@ impl RpcSession {
                 return Err(RpcError::Transport(TransportError::Closed));
             }
             Err(_) => {
-                tracing::warn!(
-                    channel_id,
-                    method_id,
-                    timeout_ms,
-                    "RPC call timed out waiting for response"
-                );
+                // Look up method name from registry for better error messages
+                let method_name = rapace_registry::ServiceRegistry::with_global(|reg| {
+                    reg.method_by_id(rapace_registry::MethodId(method_id))
+                        .map(|m| m.full_name.clone())
+                });
+
+                if let Some(method) = method_name {
+                    tracing::warn!(
+                        channel_id,
+                        method = method.as_str(),
+                        method_id,
+                        timeout_ms,
+                        "RPC call timed out waiting for response"
+                    );
+                } else {
+                    tracing::warn!(
+                        channel_id,
+                        method_id,
+                        timeout_ms,
+                        "RPC call timed out waiting for response"
+                    );
+                }
                 return Err(RpcError::DeadlineExceeded);
             }
         };

--- a/crates/rapace/tests/method_ids_generation.rs
+++ b/crates/rapace/tests/method_ids_generation.rs
@@ -1,0 +1,122 @@
+//! Test that validates the METHOD_IDS constant generation and cell_service! macro integration.
+//!
+//! This test validates the fix for issue #82, where the cell_service! macro required
+//! manual method ID specification, but the #[rapace::service] macro didn't provide
+//! a way to get all method IDs as a collection.
+
+use rapace::RpcSession;
+
+#[allow(async_fn_in_trait)]
+#[rapace::service]
+trait Calculator {
+    async fn add(&self, a: i32, b: i32) -> i32;
+    async fn subtract(&self, a: i32, b: i32) -> i32;
+    async fn multiply(&self, a: i32, b: i32) -> i32;
+}
+
+struct CalculatorImpl;
+
+impl Calculator for CalculatorImpl {
+    async fn add(&self, a: i32, b: i32) -> i32 {
+        a + b
+    }
+
+    async fn subtract(&self, a: i32, b: i32) -> i32 {
+        a - b
+    }
+
+    async fn multiply(&self, a: i32, b: i32) -> i32 {
+        a * b
+    }
+}
+
+#[test]
+fn test_method_ids_constant_exists() {
+    // Verify that the METHOD_IDS constant is generated and accessible
+    let method_ids = CalculatorServer::<CalculatorImpl>::METHOD_IDS;
+
+    // Should have exactly 3 method IDs (add, subtract, multiply)
+    assert_eq!(method_ids.len(), 3);
+
+    // Verify that the individual constants match what's in the array
+    assert!(method_ids.contains(&CALCULATOR_METHOD_ID_ADD));
+    assert!(method_ids.contains(&CALCULATOR_METHOD_ID_SUBTRACT));
+    assert!(method_ids.contains(&CALCULATOR_METHOD_ID_MULTIPLY));
+}
+
+#[test]
+fn test_method_ids_are_unique() {
+    // Verify that all method IDs are unique (no hash collisions within service)
+    let method_ids = CalculatorServer::<CalculatorImpl>::METHOD_IDS;
+    let mut sorted = method_ids.to_vec();
+    sorted.sort_unstable();
+    sorted.dedup();
+
+    assert_eq!(
+        sorted.len(),
+        method_ids.len(),
+        "METHOD_IDS contains duplicates!"
+    );
+}
+
+#[test]
+fn test_method_ids_are_deterministic() {
+    // Verify that method IDs are deterministic (same every time)
+    // This is important for distributed systems
+    let ids1 = CalculatorServer::<CalculatorImpl>::METHOD_IDS;
+    let ids2 = CalculatorServer::<CalculatorImpl>::METHOD_IDS;
+
+    assert_eq!(ids1, ids2);
+}
+
+#[test]
+fn test_individual_method_id_constants() {
+    // Verify that individual method ID constants are generated correctly
+    // These constants should match what's in METHOD_IDS
+
+    // The constants should be non-zero (FNV-1a hash shouldn't be 0 for these strings)
+    assert_ne!(CALCULATOR_METHOD_ID_ADD, 0);
+    assert_ne!(CALCULATOR_METHOD_ID_SUBTRACT, 0);
+    assert_ne!(CALCULATOR_METHOD_ID_MULTIPLY, 0);
+
+    // All should be different
+    assert_ne!(CALCULATOR_METHOD_ID_ADD, CALCULATOR_METHOD_ID_SUBTRACT);
+    assert_ne!(CALCULATOR_METHOD_ID_ADD, CALCULATOR_METHOD_ID_MULTIPLY);
+    assert_ne!(CALCULATOR_METHOD_ID_SUBTRACT, CALCULATOR_METHOD_ID_MULTIPLY);
+}
+
+#[tokio::test]
+async fn test_end_to_end_with_method_ids() -> Result<(), Box<dyn std::error::Error>> {
+    use std::sync::Arc;
+
+    // Create an in-memory transport pair
+    let (client_transport, server_transport) = rapace::Transport::mem_pair();
+
+    // Create server
+    let server = CalculatorServer::new(CalculatorImpl);
+    let server_handle = tokio::spawn(server.serve(server_transport));
+
+    // Create client session and spawn demux loop
+    let session = Arc::new(RpcSession::new(client_transport.clone()));
+    let session_clone = session.clone();
+    tokio::spawn(async move {
+        let _ = session_clone.run().await;
+    });
+    let client = CalculatorClient::new(session);
+
+    // Test that RPCs work correctly (verifying that method IDs are correct)
+    let result = client.add(5, 3).await?;
+    assert_eq!(result, 8);
+
+    let result = client.subtract(10, 4).await?;
+    assert_eq!(result, 6);
+
+    let result = client.multiply(7, 6).await?;
+    assert_eq!(result, 42);
+
+    // Cleanup
+    client_transport.close();
+    server_handle.abort();
+
+    Ok(())
+}


### PR DESCRIPTION
Fixes #82 and #83.

## Changes

**Issue #82: cell_service! macro broken**
- Generate `METHOD_IDS` constant in `#[rapace::service]` macro for ergonomic cell service usage
- Simplify `cell_service!` to automatically use generated `METHOD_IDS` (no manual array needed)
- Add fail-fast duplicate method_id detection in `DispatcherBuilder` with helpful error messages
- Include compile-time hash collision detection within services

**Issue #83: RPC timeout warnings should show method name**
- Enhanced timeout warnings to show method name from registry: `method="ServiceName.method_name"`
- Falls back gracefully to method_id if not registered
- Applied to both timeout locations in `session.rs`

## Test Coverage

Added 10 comprehensive tests covering METHOD_IDS generation, cell_service! integration, duplicate detection, and multi-service dispatch.