### PR TITLE
Fix misleading doc comment about ServiceDispatch scope

### DIFF
--- a/crates/rapace-macros/src/lib.rs
+++ b/crates/rapace-macros/src/lib.rs
@@ -353,7 +353,7 @@ fn generate_service(input: &ParsedTrait) -> Result<TokenStream2, MacroError> {
             //     .build(buffer_pool);
             // ```
             //
-            // This implementation is automatically provided when rapace_cell is in your dependency tree.
+            // Within the rapace_cell crate itself, this implementation is generated automatically; it is not emitted in downstream crates due to orphan rule restrictions (see docs above).
             const _: () = {
                 #[allow(unused_qualifications)]
                 impl<S: #trait_name + Send + Sync + 'static> #rapace_cell_path::ServiceDispatch for ::std::sync::Arc<#server_name<S>> {


### PR DESCRIPTION
Fix inaccurate documentation about when the ServiceDispatch auto-generation occurs.

The comment incorrectly stated the implementation is provided when rapace_cell is in the dependency tree. This is only true when compiling within rapace_cell itself - downstream crates cannot use it due to Rust's orphan rules. Updated the comment to clarify this implementation is generated only within rapace_cell, with a reference to the explanation above.