### PR TITLE
Auto-generate ServiceDispatch wrappers for all crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2457,6 +2457,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "test-external-service"
+version = "0.5.0"
+dependencies = [
+ "rapace",
+ "rapace-cell",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
     "demos/template-engine",
     "demos/tracing-over-rapace",
     "demos/http-tunnel",
+    "test-external-service",
     "xtask",
 ]
 exclude = ["fuzz"]

--- a/test-external-service/Cargo.toml
+++ b/test-external-service/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "test-external-service"
+version.workspace = true
+edition.workspace = true
+publish = false
+
+[dependencies]
+rapace.workspace = true
+rapace-cell = { path = "../crates/rapace-cell" }

--- a/test-external-service/README.md
+++ b/test-external-service/README.md
@@ -1,0 +1,63 @@
+# test-external-service
+
+[![Coverage Status](https://coveralls.io/repos/github/facet-rs/test-external-service/badge.svg?branch=main)](https://coveralls.io/github/facet-rs/facet?branch=main)
+[![crates.io](https://img.shields.io/crates/v/test-external-service.svg)](https://crates.io/crates/test-external-service)
+[![documentation](https://docs.rs/test-external-service/badge.svg)](https://docs.rs/test-external-service)
+[![MIT/Apache-2.0 licensed](https://img.shields.io/crates/l/test-external-service.svg)](./LICENSE)
+[![Discord](https://img.shields.io/discord/1379550208551026748?logo=discord&label=discord)](https://discord.gg/JhD7CwCJ8F)
+
+# test-external-service
+
+Integration test crate that validates auto-generated ServiceDispatch wrappers work correctly in external crates (not inside rapace-cell itself).
+
+This test demonstrates the fix for [issue #100](https://github.com/bearcove/rapace/issues/100), ensuring that the `#[rapace::service]` macro generates proper `ServiceDispatch` implementations regardless of where the service is defined.
+
+## Sponsors
+
+Thanks to all individual sponsors:
+
+<p> <a href="https://github.com/sponsors/fasterthanlime">
+<picture>
+<source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/github-dark.svg">
+<img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/github-light.svg" height="40" alt="GitHub Sponsors">
+</picture>
+</a> <a href="https://patreon.com/fasterthanlime">
+    <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/patreon-dark.svg">
+    <img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/patreon-light.svg" height="40" alt="Patreon">
+    </picture>
+</a> </p>
+
+...along with corporate sponsors:
+
+<p> <a href="https://aws.amazon.com">
+<picture>
+<source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/aws-dark.svg">
+<img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/aws-light.svg" height="40" alt="AWS">
+</picture>
+</a> <a href="https://zed.dev">
+<picture>
+<source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/zed-dark.svg">
+<img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/zed-light.svg" height="40" alt="Zed">
+</picture>
+</a> <a href="https://depot.dev?utm_source=facet">
+<picture>
+<source media="(prefers-color-scheme: dark)" srcset="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/depot-dark.svg">
+<img src="https://github.com/facet-rs/facet/raw/main/static/sponsors-v3/depot-light.svg" height="40" alt="Depot">
+</picture>
+</a> </p>
+
+...without whom this work could not exist.
+
+## Special thanks
+
+The facet logo was drawn by [Misiasart](https://misiasart.com/).
+
+## License
+
+Licensed under either of:
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](https://github.com/facet-rs/facet/blob/main/LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](https://github.com/facet-rs/facet/blob/main/LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+
+at your option.

--- a/test-external-service/README.md.in
+++ b/test-external-service/README.md.in
@@ -1,0 +1,5 @@
+# test-external-service
+
+Integration test crate that validates auto-generated ServiceDispatch wrappers work correctly in external crates (not inside rapace-cell itself).
+
+This test demonstrates the fix for [issue #100](https://github.com/bearcove/rapace/issues/100), ensuring that the `#[rapace::service]` macro generates proper `ServiceDispatch` implementations regardless of where the service is defined.

--- a/test-external-service/src/lib.rs
+++ b/test-external-service/src/lib.rs
@@ -1,0 +1,61 @@
+//! Test crate to verify external services can use auto-generated ServiceDispatch wrappers.
+//!
+//! This validates the fix for issue #100.
+
+/// A simple test service defined in an external crate (not rapace-cell)
+#[rapace::service]
+pub trait Calculator {
+    async fn add(&self, a: i32, b: i32) -> i32;
+}
+
+/// Implementation of Calculator
+pub struct CalculatorImpl;
+
+impl Calculator for CalculatorImpl {
+    async fn add(&self, a: i32, b: i32) -> i32 {
+        a + b
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rapace_cell::{DispatcherBuilder, ServiceDispatch};
+
+    #[test]
+    fn calculator_has_into_dispatch() {
+        // Create a CalculatorServer
+        let server = CalculatorServer::new(CalculatorImpl);
+
+        // The auto-generated into_dispatch() method should be available
+        let dispatch = server.into_dispatch();
+
+        // Verify it implements ServiceDispatch
+        let method_ids = dispatch.method_ids();
+        assert!(
+            !method_ids.is_empty(),
+            "Should have method IDs for Calculator service"
+        );
+    }
+
+    #[test]
+    fn calculator_dispatch_type_exists() {
+        // Verify that CalculatorDispatch type was auto-generated
+        let server = CalculatorServer::new(CalculatorImpl);
+        let _dispatch: CalculatorDispatch<_> = server.into_dispatch();
+    }
+
+    #[test]
+    fn can_build_dispatcher_with_external_service() {
+        // This is the key test - we should be able to use DispatcherBuilder
+        // with a service defined outside of rapace-cell
+        let server = CalculatorServer::new(CalculatorImpl);
+        let buffer_pool = rapace::BufferPool::new();
+
+        let _dispatcher = DispatcherBuilder::new()
+            .add_service(server.into_dispatch())
+            .build(buffer_pool);
+
+        // If we got here, the wrapper was successfully generated!
+    }
+}


### PR DESCRIPTION
## Summary

Auto-generate `ServiceDispatch` wrapper types for services in all crates, not just inside `rapace-cell`.

## Problem Addressed

Previously, the `#[rapace::service]` macro only generated `ServiceDispatch` implementations when running inside `rapace-cell` itself. External crates (like `rapace-tracing`) had to manually implement `ServiceDispatch` using the `cell_service!` macro, creating inconsistent developer experience.

## Solution

The macro now unconditionally generates a `{ServiceName}Dispatch<S>` wrapper type whenever `rapace-cell` is available in the dependency graph. The wrapper is local to the service-defining crate, satisfying Rust's orphan rules. Users can now call `.into_dispatch()` on any server.

## Testing

- Added `test-external-service` crate to validate wrapper generation in external crates
- All existing `rapace-cell` tests pass
- All `rapace` integration tests pass

Fixes #100