### PR TITLE
Contain unsafe code in dedicated locations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1888,11 +1888,11 @@ name = "rapace-cell"
 version = "0.5.0"
 dependencies = [
  "facet",
- "libc",
  "rapace",
  "rapace-introspection",
  "rapace-registry",
  "rapace-tracing",
+ "shm-primitives",
  "tokio",
  "tokio-test-lite",
  "tracing",
@@ -2454,7 +2454,10 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 name = "shm-primitives"
 version = "0.5.0"
 dependencies = [
+ "libc",
  "loom",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/rust/rapace-cell/Cargo.toml
+++ b/rust/rapace-cell/Cargo.toml
@@ -17,11 +17,11 @@ rapace = { workspace = true, features = ["shm"] }
 rapace-registry.workspace = true
 rapace-tracing = { path = "../rapace-tracing", version = "0.5.0" }
 rapace-introspection = { path = "../rapace-introspection", version = "0.5.0", optional = true }
+shm-primitives = { workspace = true, features = ["std"] }
 ur-taking-me-with-you = { path = "../ur-taking-me-with-you", version = "0.5.0" }
 tokio = { workspace = true, features = ["time"] }
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-libc.workspace = true
 facet.workspace = true
 
 [dev-dependencies]

--- a/rust/rapace-core/Cargo.toml
+++ b/rust/rapace-core/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 default = ["mem", "stream"]
 mem = []
 stream = []
-shm = ["dep:libc", "dep:static_assertions", "dep:allocator-api2", "dep:shm-primitives", "tokio/net"]
+shm = ["dep:libc", "dep:static_assertions", "dep:allocator-api2", "dep:shm-primitives", "shm-primitives/std", "tokio/net"]
 # websocket: universal feature that works on both native (tungstenite) and WASM (web-sys)
 websocket = ["dep:tokio-tungstenite"]
 # Explicit backend selection (optional, for fine-grained control)

--- a/rust/rapace-core/src/buffer_pool.rs
+++ b/rust/rapace-core/src/buffer_pool.rs
@@ -4,7 +4,17 @@
 //! allocation pressure in high-throughput scenarios. Instead of allocating
 //! a fresh `Vec<u8>` for every received frame, buffers are reused from the pool.
 
-// Allow unsafe for BufMut trait implementation which requires it
+// SAFETY: This module contains unsafe code required by the `bytes::BufMut` trait.
+//
+// The unsafe operations are:
+// 1. `unsafe impl BufMut for PooledBuf` - trait requires unsafe impl
+// 2. `advance_mut` - calls `Vec::set_len` after caller writes to uninitialized memory
+// 3. `chunk_mut` - returns `UninitSlice` pointing to Vec's spare capacity
+//
+// These are safe because:
+// - We only expose uninitialized memory that the Vec has already allocated
+// - `advance_mut` is only called after the caller has initialized the bytes
+// - The Vec's capacity/length invariants are maintained
 #![allow(unsafe_code)]
 
 use bytes::BufMut;

--- a/rust/rapace-core/src/transport/shm.rs
+++ b/rust/rapace-core/src/transport/shm.rs
@@ -6,8 +6,6 @@
 // SHM transport requires unsafe for low-level memory operations
 #![allow(unsafe_code)]
 
-mod doorbell;
-pub mod futex;
 mod hub_alloc;
 #[cfg(unix)]
 mod hub_host;
@@ -19,7 +17,6 @@ mod slot_guard;
 mod transport;
 
 pub use allocator_api2;
-pub use doorbell::{Doorbell, SignalResult, close_peer_fd};
 pub use hub_alloc::HubAllocator;
 #[cfg(unix)]
 pub use hub_host::{AddPeerOptions, HubPeerTicket};
@@ -27,3 +24,7 @@ pub use hub_session::{HubConfig, HubHost, HubPeer, HubSessionError, PeerInfo};
 pub use hub_transport::{HubHostPeerTransport, HubPeerTransport, PeerDeathCallback};
 pub use slot_guard::SlotGuard;
 pub use transport::{ShmMetrics, ShmTransport};
+
+// Re-export OS primitives from shm-primitives
+pub use shm_primitives::futex;
+pub use shm_primitives::{Doorbell, SignalResult, close_peer_fd};

--- a/rust/rapace-core/src/transport/shm/hub_alloc.rs
+++ b/rust/rapace-core/src/transport/shm/hub_alloc.rs
@@ -5,12 +5,12 @@
 use std::sync::atomic::AtomicU32;
 use std::sync::atomic::Ordering;
 
-use super::futex::futex_signal;
 use super::hub_layout::{
     ExtentHeader, FREE_LIST_END, HUB_SIZE_CLASSES, HubSlotError, HubSlotMeta, NO_OWNER,
     NUM_SIZE_CLASSES, SizeClassHeader, SlotState, decode_global_index, encode_global_index,
     pack_free_head, unpack_free_head,
 };
+use shm_primitives::futex_signal;
 
 /// A view into the hub's allocator state.
 ///

--- a/rust/rapace-core/src/transport/shm/hub_session.rs
+++ b/rust/rapace-core/src/transport/shm/hub_session.rs
@@ -9,7 +9,6 @@ use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
 
-use super::doorbell::Doorbell;
 use super::hub_alloc::{HubAllocator, init_extent_free_list};
 use super::hub_layout::{
     DEFAULT_HUB_RING_CAPACITY, ExtentHeader, HUB_SIZE_CLASSES, HubHeader, HubOffsets, HubSlotMeta,
@@ -18,6 +17,7 @@ use super::hub_layout::{
 };
 use super::layout::{DescRing, DescRingHeader};
 use crate::MsgDescHot;
+use shm_primitives::Doorbell;
 
 /// Configuration for creating a hub.
 #[derive(Debug, Clone)]

--- a/rust/rapace-core/src/transport/shm/hub_transport.rs
+++ b/rust/rapace-core/src/transport/shm/hub_transport.rs
@@ -14,11 +14,10 @@ use crate::{
     TransportError, ValidationError,
 };
 
-use super::doorbell::{Doorbell, SignalResult};
-use super::futex;
 use super::hub_layout::{HubSlotError, decode_slot_ref, encode_slot_ref};
 use super::hub_session::{HubHost, HubPeer};
 use crate::transport::Transport;
+use shm_primitives::{Doorbell, SignalResult, futex};
 
 /// Callback invoked when a peer dies.
 ///

--- a/rust/rapace-core/src/transport/shm/layout.rs
+++ b/rust/rapace-core/src/transport/shm/layout.rs
@@ -402,7 +402,7 @@ impl DataSegment {
         let result = self.inner.free(handle).map_err(convert_slot_error);
         if result.is_ok() {
             // Signal anyone waiting for slots
-            super::futex::futex_signal(self.slot_available_futex());
+            shm_primitives::futex_signal(self.slot_available_futex());
         }
         result
     }
@@ -428,7 +428,7 @@ impl DataSegment {
             .map_err(convert_slot_error);
         if result.is_ok() {
             // Signal anyone waiting for slots
-            super::futex::futex_signal(self.slot_available_futex());
+            shm_primitives::futex_signal(self.slot_available_futex());
         }
         result
     }

--- a/rust/rapace-core/src/transport/websocket.rs
+++ b/rust/rapace-core/src/transport/websocket.rs
@@ -1,3 +1,10 @@
+// SAFETY: This module contains `unsafe impl Send/Sync` for WASM types.
+//
+// On WASM, there's only one thread, so Send/Sync are trivially satisfied.
+// These impls allow using the WebSocket transport with async runtimes that
+// require Send bounds on futures.
+#![allow(unsafe_code)]
+
 use crate::MsgDescHot;
 
 /// Size of MsgDescHot in bytes (must be 64).

--- a/rust/shm-primitives/Cargo.toml
+++ b/rust/shm-primitives/Cargo.toml
@@ -21,7 +21,15 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)'] }
 [features]
 default = []
 alloc = []
-std = ["alloc"]
+std = ["alloc", "dep:libc", "dep:tokio", "dep:tracing"]
+
+[dependencies]
+libc = { workspace = true, optional = true }
+tracing = { workspace = true, optional = true }
+tokio = { workspace = true, optional = true, features = ["rt"] }
+
+[target.'cfg(unix)'.dependencies]
+tokio = { workspace = true, optional = true, features = ["net", "rt"] }
 
 [target.'cfg(loom)'.dependencies]
 loom = { version = "0.7" }

--- a/rust/shm-primitives/src/futex.rs
+++ b/rust/shm-primitives/src/futex.rs
@@ -1,6 +1,7 @@
 //! Futex operations for cross-process signaling.
 //!
 //! Uses Linux futex syscalls for efficient waiting on shared memory.
+//! On non-Linux platforms, provides fallback implementations that yield.
 
 use std::sync::atomic::AtomicU32;
 #[cfg(target_os = "linux")]
@@ -179,9 +180,9 @@ pub async fn futex_wait_async(
 mod tests {
     use super::*;
     #[cfg(target_os = "linux")]
-    use std::sync::Arc;
-    #[cfg(target_os = "linux")]
     use std::sync::atomic::Ordering;
+    #[cfg(target_os = "linux")]
+    use std::sync::Arc;
     #[cfg(target_os = "linux")]
     use std::thread;
 

--- a/rust/shm-primitives/src/lib.rs
+++ b/rust/shm-primitives/src/lib.rs
@@ -23,5 +23,16 @@ pub use treiber::{
     AllocResult, FreeError, SlotError, SlotHandle, TreiberSlab, TreiberSlabHeader, TreiberSlabRaw,
 };
 
+// OS-level primitives for SHM (requires std)
+#[cfg(all(feature = "std", unix))]
+pub mod doorbell;
+#[cfg(feature = "std")]
+pub mod futex;
+
+#[cfg(all(feature = "std", unix))]
+pub use doorbell::{Doorbell, SignalResult, close_peer_fd, set_nonblocking, validate_fd};
+#[cfg(feature = "std")]
+pub use futex::{futex_signal, futex_wait, futex_wait_async, futex_wait_async_ptr, futex_wake};
+
 #[cfg(all(test, loom))]
 mod loom_tests;


### PR DESCRIPTION
## Summary

Move OS-level SHM primitives (doorbell, futex, fcntl) from rapace-core to shm-primitives under a new `std` feature. This consolidates unsafe code for easier auditing and enables compile-time safety guarantees.

## Changes

- Add `std` feature to `shm-primitives` with doorbell, futex, and `validate_fd` modules
- Move `doorbell.rs` and `futex.rs` from `rapace-core/transport/shm/` to `shm-primitives`
- Make `rapace-cell` use `#![forbid(unsafe_code)]` (now uses `shm_primitives::validate_fd`)
- Document remaining unsafe allowances in `rapace-core` (`buffer_pool`, `owned_message`, `websocket`)

## Result

- **rapace-cell**: Now `#![forbid(unsafe_code)]` - compile-time guarantee of no unsafe
- **shm-primitives**: Contains all OS-level SHM unsafe code under `#[cfg(feature = "std")]`
- **rapace-core**: 3 documented unsafe modules remain (buffer_pool, owned_message, websocket)

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo check -p shm-primitives --features std` passes
- [x] `cargo nextest run -p shm-primitives --features std` passes

Closes #139