### PR TITLE
Remove shm reference for wasm and windows target

### DIFF
--- a/rust/rapace-cell/Cargo.toml
+++ b/rust/rapace-cell/Cargo.toml
@@ -13,7 +13,8 @@ readme = "README.md"
 rustdoc-args = ["--html-in-header", "arborium-header.html"]
 
 [dependencies]
-rapace = { workspace = true, features = ["shm"] }
+# shm for Unix SHM transport, stream for non-Unix fallback type
+rapace = { workspace = true, features = ["shm", "stream"] }
 rapace-registry.workspace = true
 rapace-tracing = { path = "../rapace-tracing", version = "0.5.0" }
 rapace-introspection = { path = "../rapace-introspection", version = "0.5.0", optional = true }

--- a/rust/rapace-core/src/frame.rs
+++ b/rust/rapace-core/src/frame.rs
@@ -28,10 +28,7 @@ pub enum Payload {
     /// Payload bytes backed by a shared-memory slot guard (frees slot on drop).
     ///
     /// Spec: `[impl frame.shm.slot-guard]` - slot remains valid for guard lifetime.
-    #[cfg(all(
-        feature = "shm",
-        not(any(target_arch = "wasm32", target_family = "windows"))
-    ))]
+    #[cfg(all(feature = "shm", unix))]
     Shm(crate::transport::shm::SlotGuard),
 }
 
@@ -43,10 +40,7 @@ impl Payload {
             Payload::Owned(buf) => buf.as_slice(),
             Payload::Bytes(buf) => buf.as_ref(),
             Payload::Pooled(buf) => buf.as_ref(),
-            #[cfg(all(
-                feature = "shm",
-                not(any(target_arch = "wasm32", target_family = "windows"))
-            ))]
+            #[cfg(all(feature = "shm", unix))]
             Payload::Shm(guard) => guard.as_ref(),
         }
     }
@@ -61,10 +55,7 @@ impl Payload {
             Payload::Owned(buf) => Some(buf.as_slice()),
             Payload::Bytes(buf) => Some(buf.as_ref()),
             Payload::Pooled(buf) => Some(buf.as_ref()),
-            #[cfg(all(
-                feature = "shm",
-                not(any(target_arch = "wasm32", target_family = "windows"))
-            ))]
+            #[cfg(all(feature = "shm", unix))]
             Payload::Shm(guard) => Some(guard.as_ref()),
         }
     }

--- a/rust/rapace-core/src/transport.rs
+++ b/rust/rapace-core/src/transport.rs
@@ -226,10 +226,7 @@ impl AnyTransport {
     /// Create a hub peer transport (for use by cells/plugins).
     ///
     /// This is used by cells connecting to a host through a shared memory hub.
-    #[cfg(all(
-        feature = "shm",
-        not(any(target_arch = "wasm32", target_family = "windows"))
-    ))]
+    #[cfg(all(feature = "shm", unix))]
     pub fn shm_hub_peer(
         peer: std::sync::Arc<shm::HubPeer>,
         doorbell: shm::Doorbell,
@@ -241,10 +238,7 @@ impl AnyTransport {
     /// Create a hub host-side per-peer transport.
     ///
     /// This is used by hosts to communicate with individual peer cells.
-    #[cfg(all(
-        feature = "shm",
-        not(any(target_arch = "wasm32", target_family = "windows"))
-    ))]
+    #[cfg(all(feature = "shm", unix))]
     pub fn shm_hub_host_peer(
         host: std::sync::Arc<shm::HubHost>,
         peer_id: u16,
@@ -302,10 +296,7 @@ impl Transport for AnyTransport {
 
 #[cfg(feature = "mem")]
 pub mod mem;
-#[cfg(all(
-    feature = "shm",
-    not(any(target_arch = "wasm32", target_family = "windows"))
-))]
+#[cfg(all(feature = "shm", unix))]
 pub mod shm;
 #[cfg(all(feature = "stream", not(target_arch = "wasm32")))]
 pub mod stream;

--- a/rust/rapace/src/lib.rs
+++ b/rust/rapace/src/lib.rs
@@ -137,10 +137,7 @@ pub mod transport {
     pub use rapace_core::websocket::WebSocketTransport;
 
     // Note: SHM transport requires more setup, exposed separately
-    #[cfg(all(
-        feature = "shm",
-        not(any(target_arch = "wasm32", target_family = "windows"))
-    ))]
+    #[cfg(all(feature = "shm", unix))]
     pub mod shm {
         pub use rapace_core::shm::*;
     }

--- a/rust/ur-taking-me-with-you/src/windows.rs
+++ b/rust/ur-taking-me-with-you/src/windows.rs
@@ -44,8 +44,11 @@ fn assign_and_leak_job(job: HANDLE, process_handle: HANDLE) -> io::Result<()> {
             CloseHandle(job);
             return Err(err);
         }
-        // Leak the job handle so it stays open for the lifetime of the parent
-        let _ = job;
+        // Intentionally leak the job handle: we never call CloseHandle(job),
+        // so the kernel job object stays alive until this process exits.
+        // (HANDLE is Copy/isize, so drop/forget are no-ops—the "leak" is
+        // simply not calling CloseHandle.)
+        let _leaked = job;
         Ok(())
     }
 }


### PR DESCRIPTION
Just doing a simple hack that removes the shm as it is not gonna happen for Windows...despite Windows kernel do have shared memory and memory mapped file support.

Doing this so that #147 would work for the minimum